### PR TITLE
Replace pin-project with pin-project-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,10 +379,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.13"
+name = "pin-project"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "powerfmt"
@@ -416,6 +436,7 @@ dependencies = [
  "clap",
  "directories",
  "percent-encoding",
+ "pin-project",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,26 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,7 +416,7 @@ dependencies = [
  "clap",
  "directories",
  "percent-encoding",
- "pin-project",
+ "pin-project-lite",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.53"
 clap = { version = "4.3.0", features = ["derive", "env"] }
 directories = "4.0.1"
 percent-encoding = "2.3.1"
+pin-project = "1.1.5"
 serde = { version = "1.0.186" }
 serde_derive = { version = "1.0.186" }
 serde_json = "1.0.78"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.53"
 clap = { version = "4.3.0", features = ["derive", "env"] }
 directories = "4.0.1"
 percent-encoding = "2.3.1"
-pin-project = "1.1.5"
+pin-project-lite = "0.2.14"
 serde = { version = "1.0.186" }
 serde_derive = { version = "1.0.186" }
 serde_json = "1.0.78"

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,8 +6,6 @@ use anyhow::{bail, ensure, Context, Result};
 use percent_encoding::percent_decode_str;
 use serde_json::Value;
 use tokio::io::BufReader;
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task;
@@ -21,10 +19,11 @@ use crate::lsp::jsonrpc::{
 };
 use crate::lsp::transport::{LspReader, LspWriter};
 use crate::lsp::InitializeParams;
+use crate::socketwrapper::{OwnedReadHalf, OwnedWriteHalf, Stream};
 
 /// Read first client message and dispatch lsp mux commands
 pub async fn process(
-    socket: TcpStream,
+    socket: Stream,
     client_id: usize,
     instance_map: Arc<Mutex<InstanceMap>>,
 ) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
@@ -21,12 +22,12 @@ mod default {
         10
     }
 
-    pub fn listen() -> (IpAddr, u16) {
+    pub fn listen() -> ListenAddr {
         // localhost & some random unprivileged port
-        (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 27_631)
+        ListenAddr::Tcp(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 27_631)
     }
 
-    pub fn connect() -> (IpAddr, u16) {
+    pub fn connect() -> ListenAddr {
         listen()
     }
 
@@ -83,6 +84,13 @@ mod de {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum ListenAddr {
+    Tcp(IpAddr, u16),
+    Unix(PathBuf),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default = "default::instance_timeout")]
@@ -94,10 +102,10 @@ pub struct Config {
     pub gc_interval: u32,
 
     #[serde(default = "default::listen")]
-    pub listen: (IpAddr, u16),
+    pub listen: ListenAddr,
 
     #[serde(default = "default::connect")]
-    pub connect: (IpAddr, u16),
+    pub connect: ListenAddr,
 
     #[serde(default = "default::log_filters")]
     pub log_filters: String,

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -3,19 +3,19 @@ use std::env;
 use anyhow::{bail, Context, Result};
 use serde::de::{DeserializeOwned, IgnoredAny};
 use tokio::io::BufReader;
-use tokio::net::TcpStream;
 
 use crate::config::Config;
 use crate::lsp::ext::{self, LspMuxOptions, StatusResponse};
 use crate::lsp::jsonrpc::{Message, Request, RequestId, Version};
 use crate::lsp::transport::{LspReader, LspWriter};
 use crate::lsp::{InitializationOptions, InitializeParams};
+use crate::socketwrapper::Stream;
 
 pub async fn ext_request<T>(config: &Config, method: ext::Request) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    let (reader, writer) = TcpStream::connect(config.connect)
+    let (reader, writer) = Stream::connect_tcp(config.connect)
         .await
         .context("connect")?
         .into_split();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod client;
 mod instance;
 mod lsp;
+mod socketwrapper;
 
 pub mod config;
 pub mod ext;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3,13 +3,13 @@ use std::env;
 
 use anyhow::{bail, Context as _, Result};
 use tokio::io::{self, BufStream};
-use tokio::net::TcpStream;
 
 use crate::config::Config;
 use crate::lsp::ext::{LspMuxOptions, Request};
 use crate::lsp::jsonrpc::Message;
 use crate::lsp::transport::{LspReader, LspWriter};
 use crate::lsp::{InitializationOptions, InitializeParams};
+use crate::socketwrapper::Stream;
 
 pub async fn run(config: &Config, server: String, args: Vec<String>) -> Result<()> {
     let cwd = env::current_dir()
@@ -23,7 +23,7 @@ pub async fn run(config: &Config, server: String, args: Vec<String>) -> Result<(
         }
     }
 
-    let mut stream = TcpStream::connect(config.connect)
+    let mut stream = Stream::connect_tcp(config.connect)
         .await
         .context("connect")?;
     let mut stdio = BufStream::new(io::join(io::stdin(), io::stdout()));

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -4,7 +4,7 @@ use std::env;
 use anyhow::{bail, Context as _, Result};
 use tokio::io::{self, BufStream};
 
-use crate::config::Config;
+use crate::config::{Config, ListenAddr};
 use crate::lsp::ext::{LspMuxOptions, Request};
 use crate::lsp::jsonrpc::Message;
 use crate::lsp::transport::{LspReader, LspWriter};
@@ -23,9 +23,11 @@ pub async fn run(config: &Config, server: String, args: Vec<String>) -> Result<(
         }
     }
 
-    let mut stream = Stream::connect_tcp(config.connect)
-        .await
-        .context("connect")?;
+    let mut stream = match config.connect {
+        ListenAddr::Tcp(ip_addr, port) => Stream::connect_tcp((ip_addr, port)).await,
+        ListenAddr::Unix(ref path) => Stream::connect_unix(path).await,
+    }
+    .context("connect")?;
     let mut stdio = BufStream::new(io::join(io::stdin(), io::stdout()));
 
     // Wait for the client to send `initialize` request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,19 +1,21 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
-use tokio::net::TcpListener;
 use tokio::task;
 use tracing::{error, info, info_span, warn, Instrument};
 
 use crate::client;
 use crate::config::Config;
 use crate::instance::InstanceMap;
+use crate::socketwrapper::Listener;
 
 pub async fn run(config: &Config) -> Result<()> {
     let instance_map = InstanceMap::new(config).await;
     let next_client_id = AtomicUsize::new(0);
 
-    let listener = TcpListener::bind(config.listen).await.context("listen")?;
+    let listener = Listener::bind_tcp(config.listen.into())
+        .await
+        .context("listen")?;
     loop {
         match listener.accept().await {
             Ok((socket, _addr)) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use tokio::task;
 use tracing::{error, info, info_span, warn, Instrument};
 
 use crate::client;
-use crate::config::Config;
+use crate::config::{Config, ListenAddr};
 use crate::instance::InstanceMap;
 use crate::socketwrapper::Listener;
 
@@ -13,9 +13,11 @@ pub async fn run(config: &Config) -> Result<()> {
     let instance_map = InstanceMap::new(config).await;
     let next_client_id = AtomicUsize::new(0);
 
-    let listener = Listener::bind_tcp(config.listen.into())
-        .await
-        .context("listen")?;
+    let listener = match config.listen {
+        ListenAddr::Tcp(ip_addr, port) => Listener::bind_tcp((ip_addr, port).into()).await,
+        ListenAddr::Unix(ref path) => Listener::bind_unix(path),
+    }
+    .context("listen")?;
     loop {
         match listener.accept().await {
             Ok((socket, _addr)) => {

--- a/src/socketwrapper.rs
+++ b/src/socketwrapper.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::{io, net};
+use std::{fs, io, net};
 
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/src/socketwrapper.rs
+++ b/src/socketwrapper.rs
@@ -1,0 +1,201 @@
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{io, net};
+
+use pin_project::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{tcp, unix, TcpListener, TcpStream, ToSocketAddrs, UnixListener, UnixStream};
+
+pub enum SocketAddr {
+    Ip(net::SocketAddr),
+    Unix(tokio::net::unix::SocketAddr),
+}
+
+impl From<net::SocketAddr> for SocketAddr {
+    fn from(val: net::SocketAddr) -> Self {
+        SocketAddr::Ip(val)
+    }
+}
+
+impl From<tokio::net::unix::SocketAddr> for SocketAddr {
+    fn from(val: tokio::net::unix::SocketAddr) -> Self {
+        SocketAddr::Unix(val)
+    }
+}
+
+#[pin_project(project = OwnedReadHalfProj)]
+pub enum OwnedReadHalf {
+    Tcp(#[pin] tcp::OwnedReadHalf),
+    Unix(#[pin] unix::OwnedReadHalf),
+}
+
+impl AsyncRead for OwnedReadHalf {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.project() {
+            OwnedReadHalfProj::Tcp(tcp) => tcp.poll_read(cx, buf),
+            OwnedReadHalfProj::Unix(unix) => unix.poll_read(cx, buf),
+        }
+    }
+}
+
+#[pin_project(project = OwnedWriteHalfProj)]
+pub enum OwnedWriteHalf {
+    Tcp(#[pin] tcp::OwnedWriteHalf),
+    Unix(#[pin] unix::OwnedWriteHalf),
+}
+
+impl AsyncWrite for OwnedWriteHalf {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.project() {
+            OwnedWriteHalfProj::Tcp(tcp) => tcp.poll_write(cx, buf),
+            OwnedWriteHalfProj::Unix(unix) => unix.poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.project() {
+            OwnedWriteHalfProj::Tcp(tcp) => tcp.poll_write_vectored(cx, bufs),
+            OwnedWriteHalfProj::Unix(unix) => unix.poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            OwnedWriteHalfProj::Tcp(tcp) => tcp.poll_flush(cx),
+            OwnedWriteHalfProj::Unix(unix) => unix.poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            OwnedWriteHalfProj::Tcp(tcp) => tcp.poll_shutdown(cx),
+            OwnedWriteHalfProj::Unix(unix) => unix.poll_shutdown(cx),
+        }
+    }
+}
+
+#[pin_project(project = StreamProj)]
+pub enum Stream {
+    Tcp(#[pin] TcpStream),
+    Unix(#[pin] UnixStream),
+}
+
+impl Stream {
+    pub async fn connect_tcp<A: ToSocketAddrs>(addr: A) -> io::Result<Stream> {
+        Ok(Stream::Tcp(TcpStream::connect(addr).await?))
+    }
+
+    pub async fn connect_unix<P: AsRef<Path>>(addr: P) -> io::Result<Stream> {
+        Ok(Stream::Unix(UnixStream::connect(addr).await?))
+    }
+
+    pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
+        match self {
+            Stream::Tcp(tcp) => {
+                let (read, write) = tcp.into_split();
+                (OwnedReadHalf::Tcp(read), OwnedWriteHalf::Tcp(write))
+            }
+            Stream::Unix(unix) => {
+                let (read, write) = unix.into_split();
+                (OwnedReadHalf::Unix(read), OwnedWriteHalf::Unix(write))
+            }
+        }
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.project() {
+            StreamProj::Tcp(tcp) => tcp.poll_read(cx, buf),
+            StreamProj::Unix(unix) => unix.poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.project() {
+            StreamProj::Tcp(tcp) => tcp.poll_write(cx, buf),
+            StreamProj::Unix(unix) => unix.poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.project() {
+            StreamProj::Tcp(tcp) => tcp.poll_write_vectored(cx, bufs),
+            StreamProj::Unix(unix) => unix.poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            StreamProj::Tcp(tcp) => tcp.poll_flush(cx),
+            StreamProj::Unix(unix) => unix.poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            StreamProj::Tcp(tcp) => tcp.poll_shutdown(cx),
+            StreamProj::Unix(unix) => unix.poll_shutdown(cx),
+        }
+    }
+}
+
+pub enum Listener {
+    Tcp(TcpListener),
+    Unix(UnixListener),
+}
+
+impl Listener {
+    pub async fn bind_tcp(addr: net::SocketAddr) -> io::Result<Listener> {
+        Ok(Listener::Tcp(TcpListener::bind(addr).await?))
+    }
+
+    pub fn bind_unix<T: AsRef<Path>>(addr: T) -> io::Result<Listener> {
+        match fs::remove_file(&addr) {
+            Ok(()) => (),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => (),
+            Err(e) => return Err(e),
+        }
+        Ok(Listener::Unix(UnixListener::bind(addr)?))
+    }
+
+    pub async fn accept(&self) -> io::Result<(Stream, SocketAddr)> {
+        match self {
+            Listener::Tcp(tcp) => {
+                let (stream, addr) = tcp.accept().await?;
+                Ok((Stream::Tcp(stream), addr.into()))
+            }
+            Listener::Unix(unix) => {
+                let (stream, addr) = unix.accept().await?;
+                Ok((Stream::Unix(stream), addr.into()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
github doesn't let me push changes into <https://github.com/pr2502/ra-multiplex/pull/66> so here you have a PR for your PR :smile:

and the change to Cargo.lock that remains after this (bump pin-project-lite from 0.2.13 to 0.2.14) can stay, no need to revert that^^